### PR TITLE
Imp update webhook payload

### DIFF
--- a/webhooks/energetica/labeler.py
+++ b/webhooks/energetica/labeler.py
@@ -38,9 +38,9 @@ async def labelhook(request):
 async def asign_energetica_label(app, body):
     logger.info('Energetica labeler task triggered')
     energetica_emails = app.dbUtils.get_energetica_emails()
-    if body.get('customer', {}).get('email', '') in energetica_emails:
+    if body.get('primaryCustomer', {}).get('email', '') in energetica_emails:
         msg = 'Moving conversation [%s] from [%s] to Energetica mailbox'
-        logger.info(msg, body.get('subject'), body['customer']['email'])
+        logger.info(msg, body.get('subject'), body['primaryCustomer']['email'])
 
         mailbox_id = await app.hsApi.get_mailbox('Energética Coop')
         await app.hsApi.change_mailbox(body['id'], mailbox_id['id'])

--- a/webhooks/tests/hs_api_test.py
+++ b/webhooks/tests/hs_api_test.py
@@ -17,7 +17,7 @@ class HelpscoutSDKTest(VCRTestCase):
             hs_sdk._hs_api.token_renew.renew_token(hs_sdk._hs_api.token_renew)
         )
         loop.run_until_complete(
-            hs_sdk.change_mailbox(756647228, 93840)
+            hs_sdk.change_mailbox(762899217, 93840)
         )
 
         self.assertEqual(len(self.cassette), 2)
@@ -52,7 +52,7 @@ class HelpscoutAPITest(VCRTestCase):
             hs_api.token_renew.renew_token(hs_api.token_renew)
         )
         loop.run_until_complete(
-            hs_api.change_mailbox(756647228, 93840)
+            hs_api.change_mailbox(762899217, 93840)
         )
 
         self.assertEqual(len(self.cassette), 2)

--- a/webhooks/tests/labeler_test.py
+++ b/webhooks/tests/labeler_test.py
@@ -21,7 +21,7 @@ class LabelerTest(unittest.TestCase):
 
     def test__you_can_not_pass(self):
         body = {
-            'customer': {'email': 'example@example.com'},
+            'primaryCustomer': {'email': 'example@example.com'},
             'id': 1234
         }
 
@@ -34,7 +34,7 @@ class LabelerTest(unittest.TestCase):
     @mock.patch('webhooks.lib.hs_api.HelpscoutSDK.get_mailbox', new=AsyncMock(return_value={'id': 5001}))
     def test__energetica_mail(self):
         body = {
-            'customer': {'email': 'example@example.com'},
+            'primaryCustomer': {'email': 'example@example.com'},
             'id': 1234
         }
         app.dbUtils.get_energetica_emails = MagicMock(
@@ -42,16 +42,16 @@ class LabelerTest(unittest.TestCase):
         )
         app.hsApi.change_mailbox = AsyncMock()
 
-        app.test_client.post(
+        request, response = app.test_client.post(
             '/energetica_labeler',
             data=json.dumps(body),
-            headers={'x-helpscout-signature': 'OVdmCjJeaW/zzSP/A5T/Y9XXxWY='}
+            headers={'x-helpscout-signature': '6SVvUvPXh2WwSvkFq8pMogPRHfE='}
         )
         app.hsApi.change_mailbox.mock.assert_called_once_with(1234, 5001)
 
     def test__no_energetica_mail(self):
         body = {
-            'customer': {'email': 'example@example.com'},
+            'primaryCustomer': {'email': 'example@example.com'},
             'id': 1234
         }
         app.dbUtils.get_energetica_emails = MagicMock(
@@ -63,7 +63,7 @@ class LabelerTest(unittest.TestCase):
         request, response = app.test_client.post(
             '/energetica_labeler',
             data=json.dumps(body),
-            headers={'x-helpscout-signature': 'OVdmCjJeaW/zzSP/A5T/Y9XXxWY='}
+            headers={'x-helpscout-signature': '6SVvUvPXh2WwSvkFq8pMogPRHfE='}
         )
 
         self.assertEqual(200, response.status)


### PR DESCRIPTION
## Context
Actually we use webhook payload v1 and this version support will end on May 23, 2022. If we intend to continue using webhook, we will need to migrate to the newer version (v2) ahead of the May 2022 deadline

- [v1 Payload](https://developer.helpscout.com/webhooks/objects/conversation/)
- [v2 Payload](https://developer.helpscout.com/mailbox-api/endpoints/conversations/get/#response)

## Changes

- Change webhook payload to v2